### PR TITLE
Gnome 3.38 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Battery Status
 ====================================
 
-*for Gnome Shell 3.10 / 3.12 / 3.14 / 3.16 / 3.18 / 3.20*
+> *For Gnome Shell 3.38*
 
 Features
 --------

--- a/battery_status@milliburn.github.com/extension.js
+++ b/battery_status@milliburn.github.com/extension.js
@@ -55,7 +55,7 @@ function enable() {
   }
 
   if (cfg.displayMode != 'icon_only') {
-    label = new St.Label({ y_align: St.Align.MIDDLE, y_expand: false });
+    label = new St.Label({ y_align: St.Align.END, y_expand: false });
     PowerIndicator.add(label);
     label_visible = true;
   }

--- a/battery_status@milliburn.github.com/extension.js
+++ b/battery_status@milliburn.github.com/extension.js
@@ -55,9 +55,8 @@ function enable() {
   }
 
   if (cfg.displayMode != 'icon_only') {
-    label = new St.Label();
-    PowerIndicator.indicators.add(
-      label, { y_align: St.Align.MIDDLE, y_fill: false });
+    label = new St.Label({ y_align: St.Align.MIDDLE, y_expand: false });
+    PowerIndicator.add(label);
     label_visible = true;
   }
   
@@ -69,11 +68,11 @@ function enable() {
 }
 
 function disable() {
-  PowerIndicator.indicators.show();
+  PowerIndicator.show();
   indicators_visible = true;
   
   if (label) {
-    PowerIndicator.indicators.remove_child(label);
+    PowerIndicator.remove_child(label);
     label.destroy();
     label = null;
     label_visible = false;
@@ -93,12 +92,12 @@ function restart() {
 function update_visible(option) {
   switch (option) {
   case 'nothing':
-    PowerIndicator.indicators.hide();
+    PowerIndicator.hide();
     indicators_visible = false;
     break;
   case 'icon':
     if (!indicators_visible) {
-      PowerIndicator.indicators.show();
+      PowerIndicator.show();
       indicators_visible = true;
     }
     if (label) {
@@ -108,7 +107,7 @@ function update_visible(option) {
     break;
   case 'all':
     if (!indicators_visible) {
-      PowerIndicator.indicators.show();
+      PowerIndicator.show();
       indicators_visible = true;
     }
     if (label && !label_visible) {

--- a/battery_status@milliburn.github.com/metadata.json
+++ b/battery_status@milliburn.github.com/metadata.json
@@ -1,7 +1,7 @@
 {
   "version": 8,
   "shell-version": [
-    "3.10", "3.12", "3.14", "3.16", "3.18", "3.20"
+    "3.38"
   ],
   "settings-schema": "org.gnome.shell.extensions.battery_status",
   "original-author": "roberth@winter-weht.net", 


### PR DESCRIPTION
Support for Gnome 3.38, possibly breaks older versions.

~The indicator's text is vertically off center, probably because the x/y properties that must now be set when creating the child aren't respected for some reason.~ Fixed in 333a49b by using `END` alignment.